### PR TITLE
fix: fix ipfs.ls() for a single file object (#3440)

### DIFF
--- a/packages/interface-ipfs-core/src/ls.js
+++ b/packages/interface-ipfs-core/src/ls.js
@@ -218,5 +218,72 @@ module.exports = (common, options) => {
       expect(output).to.have.lengthOf(1)
       expect(output[0]).to.have.property('path', `${path}/${subfile}`)
     })
+
+    it('should ls single file', async () => {
+      const dir = randomName('DIR')
+      const file = randomName('F0')
+
+      const input = { path: `${dir}/${file}`, content: randomName('D1') }
+
+      const res = await ipfs.add(input)
+      const path = `${res.cid}/${file}`
+      const output = await all(ipfs.ls(path))
+
+      expect(output).to.have.lengthOf(1)
+      expect(output[0]).to.have.property('path', path)
+    })
+
+    it('should ls single file with metadata', async () => {
+      const dir = randomName('DIR')
+      const file = randomName('F0')
+
+      const input = {
+        path: `${dir}/${file}`,
+        content: randomName('D1'),
+        mode: 0o631,
+        mtime: {
+          secs: 5000,
+          nsecs: 100
+        }
+      }
+
+      const res = await ipfs.add(input)
+      const path = `${res.cid}/${file}`
+      const output = await all(ipfs.ls(res.cid))
+
+      expect(output).to.have.lengthOf(1)
+      expect(output[0]).to.have.property('path', path)
+      expect(output[0]).to.have.property('mode', input.mode)
+      expect(output[0]).to.have.deep.property('mtime', input.mtime)
+    })
+
+    it('should ls single file without containing directory', async () => {
+      const input = { content: randomName('D1') }
+
+      const res = await ipfs.add(input)
+      const output = await all(ipfs.ls(res.cid))
+
+      expect(output).to.have.lengthOf(1)
+      expect(output[0]).to.have.property('path', res.cid.toString())
+    })
+
+    it('should ls single file without containing directory with metadata', async () => {
+      const input = {
+        content: randomName('D1'),
+        mode: 0o631,
+        mtime: {
+          secs: 5000,
+          nsecs: 100
+        }
+      }
+
+      const res = await ipfs.add(input)
+      const output = await all(ipfs.ls(res.cid))
+
+      expect(output).to.have.lengthOf(1)
+      expect(output[0]).to.have.property('path', res.cid.toString())
+      expect(output[0]).to.have.property('mode', input.mode)
+      expect(output[0]).to.have.deep.property('mtime', input.mtime)
+    })
   })
 }

--- a/packages/ipfs-core/src/components/ls.js
+++ b/packages/ipfs-core/src/components/ls.js
@@ -34,7 +34,8 @@ module.exports = function ({ ipld, preload }) {
     }
 
     if (file.unixfs.type === 'file') {
-      return mapFile(file, options)
+      yield mapFile(file, options)
+      return
     }
 
     if (file.unixfs.type.includes('dir')) {

--- a/packages/ipfs-http-server/src/api/resources/files-regular.js
+++ b/packages/ipfs-http-server/src/api/resources/files-regular.js
@@ -401,11 +401,14 @@ exports.ls = {
 
     const mapLink = link => {
       const output = {
-        Name: link.name,
         Hash: cidToString(link.cid, { base: cidBase }),
         Size: link.size,
         Type: toTypeCode(link.type),
         Depth: link.depth
+      }
+
+      if (link.name) {
+        output.Name = link.name
       }
 
       if (link.mode != null) {
@@ -421,6 +424,20 @@ exports.ls = {
       }
 
       return output
+    }
+
+    const stat = await ipfs.files.stat(path.startsWith('/ipfs/') ? path : `/ipfs/${path}`)
+
+    if (stat.type === 'file') {
+      // return single object with metadata
+      return h.response({
+        Objects: [{
+          ...mapLink(stat),
+          Hash: path,
+          Depth: 1,
+          Links: []
+        }]
+      })
     }
 
     if (!stream) {

--- a/packages/ipfs/test/interface-http-go.js
+++ b/packages/ipfs/test/interface-http-go.js
@@ -47,6 +47,14 @@ describe('interface-ipfs-core over ipfs-http-client tests against go-ipfs', () =
         reason: 'TODO not implemented in go-ipfs yet'
       },
       {
+        name: 'should ls single file with metadata',
+        reason: 'TODO not implemented in go-ipfs yet'
+      },
+      {
+        name: 'should ls single file without containing directory with metadata',
+        reason: 'TODO not implemented in go-ipfs yet'
+      },
+      {
         name: 'should override raw leaves when file is smaller than one block and metadata is present',
         reason: 'TODO not implemented in go-ipfs yet'
       },


### PR DESCRIPTION
This fixes a typo where `ipfs.ls()` returns instead of yielding from a generator.

The result is that ipfs.ls() does not work when the path is a file. I think this
should fix it, with `ls` returning a generator with a single file result.

Co-authored-by: achingbrain <alex@achingbrain.net>